### PR TITLE
fix: deploy response

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -283,12 +283,7 @@ func (c *Client) Deploy(project string, spaConfigData []byte, archiveData []byte
 	// Decode the response
 	var deployResp DeployResponse
 	if err := json.Unmarshal(respBody, &deployResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	// Check for errors
-	if !deployResp.Success {
-		return nil, fmt.Errorf("deployment failed: %s", deployResp.Error)
+		return nil, fmt.Errorf("failed to decode response: %w, body: %s", err, string(respBody))
 	}
 
 	return &deployResp, nil


### PR DESCRIPTION
Problem
At present the client expense a success property in the deploy response, which no longer exits.

Solution
This removes the check for that propert